### PR TITLE
update to use recede_or_redirect_to for mobile navigation

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -11,7 +11,7 @@ class SessionsController < ApplicationController
       log_in(@app_session)
       
       flash[:success] = t(".success")
-      redirect_to root_path, status: :see_other
+      recede_or_redirect_to root_path, status: :see_other
     else
       flash.now[:danger] = t(".incorrect_details")
       render :new, status: :unprocessable_entity


### PR DESCRIPTION
a simple change for Chapter 6.3.7 to use recede_or_redirect_to